### PR TITLE
Update config.json

### DIFF
--- a/flicd/config.json
+++ b/flicd/config.json
@@ -1,6 +1,7 @@
 {
   "image": "pschmitt/hassio-addon-{arch}-flicd",
   "name": "flicd",
+  "arch": ["armhf", "aarch64"],
   "version": "1.2",
   "slug": "flicd",
   "description": "React to flic button presses",


### PR DESCRIPTION
flicd isn't working anymore:
19-05-28 19:15:07 WARNING (MainThread) [hassio.store.data] Can't read /data/addons/git/aaa91bdd/flicd/config.json: required key not provided @ data['arch']. Got None

Can you please add arch to the config?